### PR TITLE
Added option for execution speed and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Enable the collaboration mode to work with others at the same time
 ```
 ; As long as the multiplier is not 0, continue with the program
 tst 0
---jmp 4
+--jmp 3
 hlt
 
 ; Decrement the multiplier, done once per iteration
@@ -52,20 +52,20 @@ dec 0
 
 ; Decrement the multiplicand until it's 0  and add its content onto registers 2 and 3
 tst 1
---jmp 8
-jmp 12
+--jmp 7
+jmp 11
 dec 1
 inc 2
 inc 3
-jmp 5
+jmp 4
 
 ; Move the multiplicand, now stored in register 2, back to register 1
 tst 2
---jmp 16
-jmp 1
+--jmp 15
+jmp 0
 ; move complete, go to next iteration
-jmp 1
+jmp 0
 dec 2
 inc 1
-jmp 12
+jmp 11
 ```

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ Example multiplication code
 tst 0
 --jmp 4
 hlt
+
 ; Decrement the multiplier, done once in an iteration
 dec 0
+
 ; Now decrement the multiplicand and add its content onto registers 2 and 3
 tst 1
 --jmp 8
@@ -53,6 +55,7 @@ dec 1
 inc 2
 inc 3
 jmp 5
+
 ; Move the multiplicand, now stored in the register 2, back to register 1
 tst 2
 --jmp 16

--- a/README.md
+++ b/README.md
@@ -40,23 +40,26 @@ Enable the collaboration mode to work with others at the same time
 
 Example multiplication code
 ```
-tst 1
+tst 0
 --jmp 4
 hlt
-dec 1
-
-tst 2
+; Decrement the multiplier, done once in an iteration
+dec 0
+; Now decrement the multiplicand and add its content onto registers 2 and 3
+tst 1
 --jmp 8
 jmp 12
-dec 2
-inc 3
-inc 4
-jmp 5
-
-tst 3
---jmp 15
-jmp 1
-dec 3
+dec 1
 inc 2
+inc 3
+jmp 5
+; Move the multiplicand, now stored in the register 2, back to register 1
+tst 2
+--jmp 16
+jmp 1
+; move complete, go to next iteration
+jmp 1
+dec 2
+inc 1
 jmp 12
 ```

--- a/README.md
+++ b/README.md
@@ -5,23 +5,25 @@ https://felixselter.github.io/MurmelRechner/
 
 ## Features
 ### Simple Interface
-![interface](https://user-images.githubusercontent.com/55546882/148061728-c91ef4a3-7253-462c-a496-3d371ab28062.png) 
+![interface](https://github.com/dgc08/MurmelRechner/assets/83305972/5ea747a5-26ef-48a5-a78a-061b8ce71629)
 
 
 
 1. ![load](https://user-images.githubusercontent.com/55546882/148061658-23e483ff-5fa8-421a-987d-3a59a4d7e3a9.png)Load your code
 2. ![save](https://user-images.githubusercontent.com/55546882/148061734-76d495be-0aa4-4a37-bc56-749a2ee2a5ba.png)Save your code
 3. ![flowchart](https://user-images.githubusercontent.com/55546882/148061724-ec8d5d28-309d-4873-9a26-0d2c2632fcfc.png)Generate a flowchart
-4. ![formatt](https://user-images.githubusercontent.com/55546882/148061725-5dd9ab94-e5de-476d-9c81-bc6047056b68.png)Format your code
-5. ![addregister](https://user-images.githubusercontent.com/55546882/148061720-bbba2f11-c7d2-4f93-878c-190373f1dd6c.png)Add a register/marble store
-6. ![removeregister](https://user-images.githubusercontent.com/55546882/148061732-5c8047ac-b223-43e6-ae67-c945243b703d.png)remove the last register/marble store
+4. ![format](https://user-images.githubusercontent.com/55546882/148061725-5dd9ab94-e5de-476d-9c81-bc6047056b68.png)Format your code
+5. ![add_register](https://user-images.githubusercontent.com/55546882/148061720-bbba2f11-c7d2-4f93-878c-190373f1dd6c.png)Add a register/marble store
+6. ![remove_register](https://user-images.githubusercontent.com/55546882/148061732-5c8047ac-b223-43e6-ae67-c945243b703d.png)remove the last register/marble store
 7. ![execute](https://user-images.githubusercontent.com/55546882/148061722-fc562d36-48a9-440c-a553-324a4acfd91c.png) Execute your entire code
 8. ![nextline](https://user-images.githubusercontent.com/55546882/148061731-c0e88d8e-d888-41f8-b9b3-b62d47ea682d.png)Execute this line. The current position is indicated by this pointer ![pointer](https://user-images.githubusercontent.com/55546882/148063270-7ed1955c-bf79-44c1-9df1-51b103d24272.png)
 9. ![Stop](https://user-images.githubusercontent.com/55546882/150634279-bcd4c7cb-d995-4677-8b91-fbf1a7b0f7e3.png) Click this to stop your program if youre stuck in an infinite loop
-10. ![collaboration](https://user-images.githubusercontent.com/55546882/148063904-1a50f737-1c97-4c0d-9cb0-a13fb65e0db7.png)Enable the collaboration mode
-11. ![fullscreen](https://user-images.githubusercontent.com/55546882/148063906-0b35c442-9ec7-43fc-bda9-a5f57d8bd66f.png)Enter the fullscreen mode
-12. ![id](https://user-images.githubusercontent.com/55546882/148065155-0ce3572b-c0e5-4694-99be-06e547b85215.png) Click the id to get a link so you can invite others
-
+10. ![increase_speed](https://user-images.githubusercontent.com/55546882/148061720-bbba2f11-c7d2-4f93-878c-190373f1dd6c.png)Increase Execution speed
+11. ![decrease_speed](https://user-images.githubusercontent.com/55546882/148061732-5c8047ac-b223-43e6-ae67-c945243b703d.png)Decrease Execution speed
+12. ![instruction_speed](https://github.com/dgc08/MurmelRechner/assets/83305972/abcc7713-6753-4f9d-8079-d02986e09a5a) Click the execution speed label to reset it to 1
+13. ![collaboration](https://user-images.githubusercontent.com/55546882/148063904-1a50f737-1c97-4c0d-9cb0-a13fb65e0db7.png)Enable the collaboration mode
+14. ![fullscreen](https://user-images.githubusercontent.com/55546882/148063906-0b35c442-9ec7-43fc-bda9-a5f57d8bd66f.png)Enter the fullscreen mode
+15. ![id](https://user-images.githubusercontent.com/55546882/148065155-0ce3572b-c0e5-4694-99be-06e547b85215.png) Click the id to get a link so you can invite others
 ### Beautiful syntax highlighting
 ![syntax](https://user-images.githubusercontent.com/55546882/148062386-b810ba2e-40a4-4183-a949-d1f27a3521c5.png)
 
@@ -38,16 +40,17 @@ It can automatically generate a flowchart from your code
 ### Collaborative editing:
 Enable the collaboration mode to work with others at the same time
 
-Example multiplication code
+### Example multiplication code
 ```
+; As long as the multiplier is not 0, continue with the program
 tst 0
 --jmp 4
 hlt
 
-; Decrement the multiplier, done once in an iteration
+; Decrement the multiplier, done once per iteration
 dec 0
 
-; Now decrement the multiplicand and add its content onto registers 2 and 3
+; Decrement the multiplicand until it's 0  and add its content onto registers 2 and 3
 tst 1
 --jmp 8
 jmp 12
@@ -56,7 +59,7 @@ inc 2
 inc 3
 jmp 5
 
-; Move the multiplicand, now stored in the register 2, back to register 1
+; Move the multiplicand, now stored in register 2, back to register 1
 tst 2
 --jmp 16
 jmp 1

--- a/css/simulator.css
+++ b/css/simulator.css
@@ -1,9 +1,10 @@
 #scroll-left {
     overflow-y: auto;
+    overflow-x: auto;
     width: 100%;
     height: 100%;
     display: flex;
-    justify-content: center;
+    justify-content: safe center;
     flex-direction: column;
 }
 

--- a/css/syntax.css
+++ b/css/syntax.css
@@ -27,6 +27,11 @@
     color: #dc143c;
 }
 
+.format-comment {
+  color: grey;
+}
+
+
 .format-error {
     text-decoration-line: underline;
     text-decoration-style: wavy;

--- a/index.html
+++ b/index.html
@@ -80,6 +80,9 @@
         <a><i class="fas fa-play fa-2x" onclick="execute();"></i></a>
         <a><i class="fas fa-arrow-circle-right fa-2x" onclick="shouldExecute=true; processLine(); if (!shouldExecute)resetSimulator();"></i></a>
         <a><i class="fas fa-hand-paper fa-2x" onclick="resetSimulator();"></i></a>
+        <a><i class="fas fa-minus fa-2x" onclick="decreaseSpeed();"></i></a>
+        <a><i class="fas fa-plus fa-2x" onclick="increaseSpeed();"></i></a>
+        <a><span id="speedLabel" onclick="resetSpeed();" style="cursor: pointer; font-size: 1.5em; color: white;">1 Hz</span></a>
         <a target="_blank" rel="noopener noreferrer" id="peerAdress"></a>
         <a id="collaborationButton"><i onclick="createCollaboration();" class="fas fa-user-plus fa-2x"></i></a>
         <a><i id="fullscreen" onclick="toggleFullscreen();" class="fas fa-expand fa-2x"></i></a>

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
         <a><i class="fas fa-hand-paper fa-2x" onclick="resetSimulator();"></i></a>
         <a><i class="fas fa-minus fa-2x" onclick="decreaseSpeed();"></i></a>
         <a><i class="fas fa-plus fa-2x" onclick="increaseSpeed();"></i></a>
-        <a><span id="speedLabel" onclick="resetSpeed();" style="cursor: pointer; font-size: 1.5em; color: white;">1 Hz</span></a>
+        <a><span id="speedLabel" onclick="resetSpeed();" style="cursor: pointer; font-size: 1.5em; color: white;">Instructions/s: 1</span></a>
         <a target="_blank" rel="noopener noreferrer" id="peerAdress"></a>
         <a id="collaborationButton"><i onclick="createCollaboration();" class="fas fa-user-plus fa-2x"></i></a>
         <a><i id="fullscreen" onclick="toggleFullscreen();" class="fas fa-expand fa-2x"></i></a>

--- a/js/clean.js
+++ b/js/clean.js
@@ -1,7 +1,7 @@
 function cleanCode() {
   const textarea = document.getElementById('editing');
 
-  const regex = /inc [0-9]+|dec [0-9]+|tst [0-9]+|jmp [0-9]+|hlt|\n|-*/g;
+  const regex = /inc [0-9]+|dec [0-9]+|tst [0-9]+|jmp [0-9]+|hlt|\n|(?:;.*)/g;
   let matches = textarea.value.match(regex);
 
   // remove empty lines that get produced if regex not matches
@@ -51,8 +51,8 @@ function cleanCode() {
 function getCleanCode(code) {
   const textarea = document.getElementById('editing');
 
-  const regex = /inc [0-9]+|dec [0-9]+|tst [0-9]+|jmp [0-9]+|hlt/g;
-  const matches = textarea.value.match(regex);
+  const regex_code = /inc [0-9]+|dec [0-9]+|tst [0-9]+|jmp [0-9]+|hlt/g;
+  const matches = textarea.value.match(regex_code);
 
   return matches;
 }

--- a/js/editor.js
+++ b/js/editor.js
@@ -80,7 +80,7 @@ function update() {
   linenums.value = '';
 
   // add line number for every line that is not empty
-  let counter = 1;
+  let counter = 0;
   for (let i = 0; i < lines.length; i++) {
     if (lines[i] != '' && !lines[i].startsWith(';')) {
       linenums.value += counter + '\n';

--- a/js/editor.js
+++ b/js/editor.js
@@ -49,6 +49,14 @@ function update() {
         match: /^(hlt)/,
       },
       {
+        name: 'format-comment',
+        match: [/^;(.*)/, '<span class="format-comment">;</span>', ''],
+      },
+      {
+        name: 'format-comment',
+        match: [/^(\s*)^;(.*)/, '<span class="format-comment"> ;</span>', ''],
+      },
+      {
         name: 'format-none',
         match: /^(&#10;)/,
       },
@@ -74,7 +82,7 @@ function update() {
   // add line number for every line that is not empty
   let counter = 1;
   for (let i = 0; i < lines.length; i++) {
-    if (lines[i] != '') {
+    if (lines[i] != '' && !lines[i].startsWith(';')) {
       linenums.value += counter + '\n';
       counter++;
     } else {

--- a/js/flowchart.js
+++ b/js/flowchart.js
@@ -57,7 +57,7 @@ function generateFlowChartCode() {
   code = `start=>start: Start\n`;
 
   source.forEach((cmd, index) => {
-    const line = index + 1;
+    const line = index;
     let nodetype = 'operation';
 
     if (cmd.startsWith('dec')) {
@@ -75,7 +75,7 @@ function generateFlowChartCode() {
 
   code += `\nstart->node1\n`;
   source.forEach((cmd, index) => {
-    const line = index + 1;
+    const line = index;
 
     if (cmd.startsWith('tst')) {
       code += `node${line}(yes)->node${line + 1}\n`;

--- a/js/register.js
+++ b/js/register.js
@@ -18,6 +18,8 @@ function addRegister() {
 function removeRegister() {
     const registerParent = document.getElementById('scroll-left');
     registerParent.removeChild(registerParent.lastElementChild);
+
+    registers.pop(); // Remove value
 }
 
 function addToRegister(index) {

--- a/js/simulator.js
+++ b/js/simulator.js
@@ -87,8 +87,8 @@ function executeLine() {
       break;
 
     case 'tst':
-      // If register exists and it does not conatin content
-      if (registers[param] != null && !(registers[param] > 0)) line++;
+      // If register doesnt exist or is null, skip next line
+      if (registers[param] == null || registers[param] == 0) line++;
       break;
 
     case 'hlt':

--- a/js/simulator.js
+++ b/js/simulator.js
@@ -5,21 +5,36 @@ var shouldExecute = false;
 var sleepDuration = 1000;
 
 function updateSpeedLabel() {
-  const freq = 1000 / sleepDuration;
-  document.getElementById('speedLabel').innerText = `${freq} Hz`;
+  if (sleepDuration != 0) {
+    const freq = 1000 / sleepDuration;
+    document.getElementById('speedLabel').innerText = `Instructions/s: ${freq}`;
+  }
+  else {
+    document.getElementById('speedLabel').innerText = 'Instructions/s: MAX';
+  }
 }
 
 function increaseSpeed() {
   sleepDuration = sleepDuration / 2;
-  updateSpeedLabel()
+  if (sleepDuration < 10) {
+    sleepDuration = 0;
+  }
+  updateSpeedLabel();
 }
 
 function decreaseSpeed() {
   if (sleepDuration == 1000) {
     return;
   }
-  sleepDuration *= 2;
-  updateSpeedLabel()
+
+  if (sleepDuration == 0) {
+    sleepDuration = 15.625; // 64 Hz
+  }
+  else {
+    sleepDuration *= 2;
+  }
+
+  updateSpeedLabel();
 }
 
 function resetSpeed() {
@@ -98,18 +113,20 @@ function executeLine() {
 
 async function execute() {
   shouldExecute = true;
-  while (true) {
+  while (shouldExecute) {
     processLine();
+    await sleep(sleepDuration);
     if (!shouldExecute) {
       await sleep(sleepDuration);
       resetSimulator();
-      break;
     }
-    await sleep(sleepDuration);
   }
 }
 
 function sleep(milliseconds) {
+  if (sleepDuration == 0) {
+    return new Promise((resolve) => setTimeout(resolve, 0.1)); // A small delay is needed or the screen won't properly update
+  }
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 

--- a/js/simulator.js
+++ b/js/simulator.js
@@ -1,5 +1,5 @@
 var registers = [];
-var line = 1;
+var line = 0;
 var shouldExecute = false;
 
 var sleepDuration = 1000;
@@ -63,7 +63,7 @@ function executeLine() {
   // setup pointer
   const pointer = document.getElementById('pointer');
 
-  const content = code[line - 1]
+  const content = code[line - 1];
   const cmd = content.substring(0, 3);
   const param = parseInt(content.substring(3, content.length));
 
@@ -83,7 +83,7 @@ function executeLine() {
   // evaluate code
   switch (cmd) {
     case 'jmp':
-      line = param - 1;
+      line = param;
       break;
 
     case 'tst':
@@ -116,22 +116,20 @@ async function execute() {
   while (shouldExecute) {
     processLine();
     await sleep(sleepDuration);
-    if (!shouldExecute) {
-      await sleep(sleepDuration);
-      resetSimulator();
-    }
   }
+  await sleep(sleepDuration);
+  resetSimulator();
 }
 
 function sleep(milliseconds) {
   if (sleepDuration == 0) {
-    return new Promise((resolve) => setTimeout(resolve, 0.1)); // A small delay is needed or the screen won't properly update
+    return new Promise((resolve) => setTimeout(resolve, 0)); // A small delay is needed or the screen won't properly update (for some reason putting 0 here works, javascript kinda strange)
   }
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 function resetSimulator() {
-  line = 1;
+  line = 0;
   shouldExecute = false;
   pointer.style.top = '-4pt';
   pointer.style.color = 'red';

--- a/js/simulator.js
+++ b/js/simulator.js
@@ -55,7 +55,7 @@ function executeLine() {
     shouldExecute = false;
     return;
   }
-  if (line > code.length) {
+  if (line > code.length-1) {
     shouldExecute = false;
     return;
   }
@@ -63,7 +63,7 @@ function executeLine() {
   // setup pointer
   const pointer = document.getElementById('pointer');
 
-  const content = code[line - 1];
+  const content = code[line];
   const cmd = content.substring(0, 3);
   const param = parseInt(content.substring(3, content.length));
 
@@ -74,7 +74,7 @@ function executeLine() {
   for (let i = 0; i < lines.length; i++) {
     const lineContent = lines[i];
     if (lineContent != '' && !lineContent.startsWith(';')) linesOfCode++; // check if this line is code
-    if (linesOfCode == line) {
+    if (linesOfCode-1 == line) {
       pointer.style.top = i * 20 - 4 + 'pt';
       break;
     }
@@ -84,11 +84,16 @@ function executeLine() {
   switch (cmd) {
     case 'jmp':
       line = param;
-      break;
+      return;
 
     case 'tst':
-      // If register doesnt exist or is null, skip next line
-      if (registers[param] == null || registers[param] == 0) line++;
+    checkRegisterCount(param);
+      if (registers[param]==0)
+        line++;
+      if (registers[param] == null){
+        line++;
+        registers[param] = 0;
+      }
       break;
 
     case 'hlt':
@@ -117,7 +122,6 @@ async function execute() {
     processLine();
     await sleep(sleepDuration);
   }
-  await sleep(sleepDuration);
   resetSimulator();
 }
 

--- a/js/simulator.js
+++ b/js/simulator.js
@@ -58,7 +58,7 @@ function executeLine() {
 
   for (let i = 0; i < lines.length; i++) {
     const lineContent = lines[i];
-    if (lineContent != '') linesOfCode++; // check if this line is code
+    if (lineContent != '' && !lineContent.startsWith(';')) linesOfCode++; // check if this line is code
     if (linesOfCode == line) {
       pointer.style.top = i * 20 - 4 + 'pt';
       break;

--- a/js/simulator.js
+++ b/js/simulator.js
@@ -2,6 +2,31 @@ var registers = [];
 var line = 1;
 var shouldExecute = false;
 
+var sleepDuration = 1000;
+
+function updateSpeedLabel() {
+  const freq = 1000 / sleepDuration;
+  document.getElementById('speedLabel').innerText = `${freq} Hz`;
+}
+
+function increaseSpeed() {
+  sleepDuration = sleepDuration / 2;
+  updateSpeedLabel()
+}
+
+function decreaseSpeed() {
+  if (sleepDuration == 1000) {
+    return;
+  }
+  sleepDuration *= 2;
+  updateSpeedLabel()
+}
+
+function resetSpeed() {
+  sleepDuration = 1000;
+  updateSpeedLabel();
+}
+
 function processLine() {
   pointer.style.color = '#04aa6d';
   return executeLine();
@@ -23,7 +48,7 @@ function executeLine() {
   // setup pointer
   const pointer = document.getElementById('pointer');
 
-  const content = code[line - 1];
+  const content = code[line - 1]
   const cmd = content.substring(0, 3);
   const param = parseInt(content.substring(3, content.length));
 
@@ -48,7 +73,7 @@ function executeLine() {
 
     case 'tst':
       // If register exists and it does not conatin content
-      if (registers[param - 1] != null && !(registers[param - 1] > 0)) line++;
+      if (registers[param] != null && !(registers[param] > 0)) line++;
       break;
 
     case 'hlt':
@@ -56,11 +81,11 @@ function executeLine() {
       return;
 
     case 'inc':
-      addToRegister(param - 1);
+      addToRegister(param);
       break;
 
     case 'dec':
-      removeFromRegister(param - 1);
+      removeFromRegister(param);
       break;
 
     default:
@@ -76,11 +101,11 @@ async function execute() {
   while (true) {
     processLine();
     if (!shouldExecute) {
-      await sleep(1000);
+      await sleep(sleepDuration);
       resetSimulator();
       break;
     }
-    await sleep(1000);
+    await sleep(sleepDuration);
   }
 }
 
@@ -89,8 +114,8 @@ function sleep(milliseconds) {
 }
 
 function resetSimulator() {
-  shouldExecute = false;
   line = 1;
+  shouldExecute = false;
   pointer.style.top = '-4pt';
   pointer.style.color = 'red';
 }


### PR DESCRIPTION
New features:
- Added option for the execution speed: Pressing the increase button will double the amount of instructions per second, the decrease button will half it
- Added Assembly-like comments with `;`, `cleanCode()` moves any comment at the end of the line into a new one though (sorry that is my first time with regex)

Major changes:
- I changed the indexing for the registers and instructions from starting at 1 to starting at 0. I know you did that on purpose, but even my teacher said it should be starting at 0, there is no reason for it to start it at 1. If you are unhappy with this, you can always change it back tho
 
Minor changes / Bugfixes:
- Deleting a register will also `pop()` it from the `registers` array. This is helpful if you for example want to clear an output register quickly
- Previously, `tst` treated registers which don't exist like "full" registers, which is stupid as new registers are initialized with 0. Nonexistent registers are now treated like empty ones.
- Fixed bug that if there were too many registers, you could only see/scroll to the last ones
- Cleaned up some typos and refactored some parts of the code to be more readable